### PR TITLE
Implement reduced 3-body emax

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -11,3 +11,4 @@ tmp*
 build/
 .vscode/
 .cache/
+CMakeUserPresets.json

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,8 @@ add_subdirectory(armadillo)
 add_subdirectory(half)
 add_subdirectory(boost_src)
 
+add_subdirectory(profiling)
+
 if(IMSRG_BUILD_PYTHON_BINDINGS)
     add_subdirectory(pybind11)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,22 @@
 cmake_minimum_required(VERSION 3.18)
 
+# Determine if imsrg++ is built as a subproject (using add_subdirectory)
+# or if it is the main project.
+if(NOT DEFINED IMSRGPLUSPLUS_MAIN_PROJECT)
+  set(IMSRGPLUSPLUS_MAIN_PROJECT OFF)
+  if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(IMSRGPLUSPLUS_MAIN_PROJECT ON)
+    message(STATUS "CMake version: ${CMAKE_VERSION}")
+  endif()
+endif()
+
+# Set the default CMAKE_BUILD_TYPE to Release.
+# This should be done before the project command since the latter can set
+# CMAKE_BUILD_TYPE itself (it does so for nmake).
+if(IMSRGPLUSPLUS_MAIN_PROJECT AND NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
 project(imsrg++ VERSION 0.1.0)
 
 find_package(OpenMP REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.18)
 
+option(IMSRG_BUILD_PYTHON_BINDINGS "Build Python bindings" ON)
+
 # Determine if imsrg++ is built as a subproject (using add_subdirectory)
 # or if it is the main project.
 if(NOT DEFINED IMSRGPLUSPLUS_MAIN_PROJECT)
@@ -30,13 +32,18 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 set(IMSRGPLUSPLUS_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-# We only need this for the Python bindings.
-# In principle, everything should be faster if we could avoid this.
-set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+if(IMSRG_BUILD_PYTHON_BINDINGS)
+    # We only need this for the Python bindings.
+    # In principle, everything should be faster if we could avoid this.
+    set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+endif()
 
 add_subdirectory(armadillo)
 add_subdirectory(half)
-add_subdirectory(pybind11)
+
+if(IMSRG_BUILD_PYTHON_BINDINGS)
+    add_subdirectory(pybind11)
+endif()
 
 # Add a custom command that produces version.cpp, plus
 # a dummy output that's not actually produced, in order
@@ -46,17 +53,6 @@ ADD_CUSTOM_COMMAND(
            ${CMAKE_CURRENT_BINARY_DIR}/_version.cc
     COMMAND ${CMAKE_COMMAND} -P
             ${CMAKE_CURRENT_SOURCE_DIR}/git_version.cmake)
-
-# At some point this should not be here because
-# this belongs in a CMake preset, not in the core CMake
-# build structure
-add_compile_options(
-    "-Wall"
-    "-Wextra"
-    "-Wno-comment"
-    # "-Werror"
-    "$<$<CONFIG:RELEASE>:-O3>"
-)
 
 add_library(
     AngMom
@@ -515,9 +511,11 @@ target_link_libraries(
     OpenMP::OpenMP_CXX
 )
 
-pybind11_add_module(pyIMSRG pyIMSRG.cc)
-target_link_libraries(
-    pyIMSRG
-    PRIVATE
-    IMSRG
-)
+if(IMSRG_BUILD_PYTHON_BINDINGS)
+    pybind11_add_module(pyIMSRG pyIMSRG.cc)
+    target_link_libraries(
+        pyIMSRG
+        PRIVATE
+        IMSRG
+    )
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,8 @@ project(imsrg++ VERSION 0.1.0)
 find_package(OpenMP REQUIRED)
 find_package(BLAS REQUIRED)
 find_package(GSL REQUIRED)
-find_package(Boost REQUIRED COMPONENTS iostreams)
+find_package(Boost REQUIRED)
+find_package(ZLIB REQUIRED)
 
 
 set(CMAKE_CXX_STANDARD 11)
@@ -40,6 +41,7 @@ endif()
 
 add_subdirectory(armadillo)
 add_subdirectory(half)
+add_subdirectory(boost_src)
 
 if(IMSRG_BUILD_PYTHON_BINDINGS)
     add_subdirectory(pybind11)
@@ -161,7 +163,7 @@ add_library(
 target_link_libraries(
     ThreeBodyStorage_no2b
     PUBLIC
-    Boost::iostreams
+    IMSRGBoostZip
     HalfPrecision
     ModelSpace
     ThreeBodyStorage
@@ -177,7 +179,7 @@ add_library(
 target_link_libraries(
     ThreeBodyStorage_mono
     PUBLIC
-    Boost::iostreams
+    IMSRGBoostZip
     HalfPrecision
     ModelSpace
     ThreeBodyStorage
@@ -271,7 +273,7 @@ target_link_libraries(
     ThreeBodyME
     PRIVATE
     OpenMP::OpenMP_CXX
-    Boost::iostreams
+    IMSRGBoostZip
     AngMom
     PhysicalConstants
     Version

--- a/src/Commutator.cc
+++ b/src/Commutator.cc
@@ -3478,8 +3478,10 @@ void comm232ss_new( const Operator& X, const Operator& Y, Operator& Z )
     // Now fill the matrices
     comm232_new_FillMatrices(Z, X, Y, dim_abc, dim_i, dim_klj, j2i, x_has_3, y_has_3, abc_list, klj_list_i, e_fermi, abc_occ_list, obc_orbits, recoupling_cache, recoupling_cache_lookup, X2MAT, Y2MAT, X3MAT, Y3MAT);
 
+    double tmatmul_start= omp_get_wtime();
     // now we do the mat mult
     ZMAT_list[obc_key] =  (  X2MAT * Y3MAT - Y2MAT * X3MAT  ) ;
+    Z.profiler.timer[std::string(__func__)+", mat mul"] += omp_get_wtime() - tmatmul_start;
 
   }// for iter_i in local one body channels
 

--- a/src/Commutator.cc
+++ b/src/Commutator.cc
@@ -2386,6 +2386,7 @@ void comm231ss( const Operator& X, const Operator& Y, Operator& Z )
   for (size_t i=0; i<norb; i++)
   {
     Orbit& oi = Z.modelspace->GetOrbit(i);
+    if (!Z.ThreeBody.IsOrbitIn3BodyEMaxTruncation(oi)) continue;
     int ei = 2*oi.n + oi.l;
     double d_ei = std::abs( ei - e_fermi[oi.tz2]);
     double occnat_i = oi.occ_nat;
@@ -2394,6 +2395,7 @@ void comm231ss( const Operator& X, const Operator& Y, Operator& Z )
     {
       if (j>i) continue;
       Orbit& oj = Z.modelspace->GetOrbit(j);
+      if (!Z.ThreeBody.IsOrbitIn3BodyEMaxTruncation(oj)) continue;
       int ej = 2*oj.n + oj.l;
       double d_ej = std::abs( ej - e_fermi[oj.tz2] );
       double occnat_j = oj.occ_nat;
@@ -2409,6 +2411,8 @@ void comm231ss( const Operator& X, const Operator& Y, Operator& Z )
           Ket& bra = tbc.GetKet(ibra);
           int a = bra.p;
           int b = bra.q;
+          if (!Z.ThreeBody.IsOrbitIn3BodyEMaxTruncation(a)) continue;
+          if (!Z.ThreeBody.IsOrbitIn3BodyEMaxTruncation(b)) continue;
           int ea = 2*bra.op->n + bra.op->l;
           int eb = 2*bra.oq->n + bra.oq->l;
           double occnat_a = bra.op->occ_nat;
@@ -2428,6 +2432,8 @@ void comm231ss( const Operator& X, const Operator& Y, Operator& Z )
             Ket& ket = tbc.GetKet(iket);
             int c = ket.p;
             int d = ket.q;
+            if (!Z.ThreeBody.IsOrbitIn3BodyEMaxTruncation(c)) continue;
+            if (!Z.ThreeBody.IsOrbitIn3BodyEMaxTruncation(d)) continue;
             int ec = 2*ket.op->n + ket.op->l;
             int ed = 2*ket.oq->n + ket.oq->l;
             double d_ec = std::abs( ec - e_fermi[ket.op->tz2]);

--- a/src/Commutator.cc
+++ b/src/Commutator.cc
@@ -6058,7 +6058,7 @@ void comm223ss( const Operator& X, const Operator& Y, Operator& Z )
      size_t nbras3 = Tbc_bra.GetNumberKets();
      for (size_t ibra=0;ibra<nbras3; ibra++)
      {
-       bra_ket_channels.push_back( { it.first[0],it.first[1], ibra } ); // (ch_bra, ch_ket,ibra)
+       bra_ket_channels.push_back( { it.first[0],it.first[1], static_cast<size_t>(ibra) } ); // (ch_bra, ch_ket,ibra)
      }
   }
   size_t n_bra_ket_ch = bra_ket_channels.size();

--- a/src/Commutator.cc
+++ b/src/Commutator.cc
@@ -3725,6 +3725,9 @@ void comm232ss_new( const Operator& X, const Operator& Y, Operator& Z )
   ) {
     const auto& Y3 = Y.ThreeBody;
     const auto& X3 = X.ThreeBody;
+
+    // With a bit more work, we can 2 loops for the 3-body part
+    #pragma omp parallel for
     for (size_t ind_abc=0; ind_abc<dim_abc; ind_abc++) // rows of X2MAT
     {
 

--- a/src/Commutator.cc
+++ b/src/Commutator.cc
@@ -196,7 +196,16 @@ Operator CommutatorScalarScalar( const Operator& X, const Operator& Y)
    }
 
 
-   if (use_imsrg3 and (X.Norm() > threebody_threshold) and (Y.Norm() > threebody_threshold) )
+   if (use_imsrg3)
+   {
+      // This one is so important we always include it
+       if ( comm_term_on["comm133ss"])
+       {
+        //important for suppressing off-diagonal H3
+        std::cout << " comm133 " << std::endl;
+        comm133ss(X, Y, Z);  // scales as n^7, but really more like n^6
+       }
+   if ((X.Norm() > threebody_threshold) || (Y.Norm() > threebody_threshold)) 
    {
        X.profiler.counter["N_ScalarCommutators_3b"] += 1;
 
@@ -245,12 +254,13 @@ Operator CommutatorScalarScalar( const Operator& X, const Operator& Y)
 //       comm232ss_debug(X, Y, Z);   // this is the slowest n^7 term
        }
 
-       if ( comm_term_on["comm133ss"])
-       {
-        //important for suppressing off-diagonal H3
-        std::cout << " comm133 " << std::endl;
-        comm133ss(X, Y, Z);  // scales as n^7, but really more like n^6
-       }
+      // This one is so important we always include it
+      //  if ( comm_term_on["comm133ss"])
+      //  {
+      //   //important for suppressing off-diagonal H3
+      //   std::cout << " comm133 " << std::endl;
+      //   comm133ss(X, Y, Z);  // scales as n^7, but really more like n^6
+      //  }
 
       if ( not use_imsrg3_n7 )
       {
@@ -309,7 +319,8 @@ Operator CommutatorScalarScalar( const Operator& X, const Operator& Y)
 
      // after going through once, we've stored all the 6js (and maybe 9js), so we can run in OMP loops from now on
      X.modelspace->scalar3b_transform_first_pass = false;
-   }
+   } // if threshold
+   } // if use imsrg3
 
    // TODO: I don't like that this gets done here. It should be in the individual commutator expressions themselves
    // As it currently is, it invites a mistake of updating the wrong triangle of the matrix.

--- a/src/Commutator.cc
+++ b/src/Commutator.cc
@@ -6642,11 +6642,11 @@ void comm223ss( const Operator& X, const Operator& Y, Operator& Z )
   std::vector< std::array<size_t,3> > bra_ket_channels;
   for ( auto& it : Z.ThreeBody.Get_ch_start() )
   {
-     ThreeBodyChannel& Tbc_bra = Z.modelspace->GetThreeBodyChannel( it.first[0]);
+     ThreeBodyChannel& Tbc_bra = Z.modelspace->GetThreeBodyChannel( it.first.ch_bra);
      size_t nbras3 = Tbc_bra.GetNumberKets();
      for (size_t ibra=0;ibra<nbras3; ibra++)
      {
-       bra_ket_channels.push_back( { it.first[0],it.first[1], static_cast<size_t>(ibra) } ); // (ch_bra, ch_ket,ibra)
+       bra_ket_channels.push_back( { it.first.ch_bra,it.first.ch_ket, static_cast<size_t>(ibra) } ); // (ch_bra, ch_ket,ibra)
      }
   }
   size_t n_bra_ket_ch = bra_ket_channels.size();

--- a/src/Commutator.cc
+++ b/src/Commutator.cc
@@ -2913,6 +2913,7 @@ void comm232ss( const Operator& X, const Operator& Y, Operator& Z )
   for ( auto j : Z.modelspace->all_orbits )
   {
     Orbit& oj = Z.modelspace->GetOrbit(j);
+    if (!Y3.IsOrbitIn3BodyEMaxTruncation(oj)) continue;
     std::array<int,3> obc = {oj.j2,oj.l%2,oj.tz2};
     if ( local_one_body_channels.find(obc) == local_one_body_channels.end() ) local_one_body_channels[obc] = {j};
     else local_one_body_channels[obc].push_back(j);
@@ -2961,6 +2962,8 @@ void comm232ss( const Operator& X, const Operator& Y, Operator& Z )
         for ( size_t iket_kl=0; iket_kl<nkets_kl; iket_kl++)
         {
           Ket& ket_kl = tbc_kl.GetKet(iket_kl);
+          if (!Y3.IsOrbitIn3BodyEMaxTruncation(ket_kl.p)) continue;
+          if (!Y3.IsOrbitIn3BodyEMaxTruncation(ket_kl.q)) continue;
           int e_k = 2*ket_kl.op->n + ket_kl.op->l;
           int e_l = 2*ket_kl.oq->n + ket_kl.oq->l;
           if ( (e_k + e_l) > Z.modelspace->GetE3max()) continue;
@@ -2971,7 +2974,8 @@ void comm232ss( const Operator& X, const Operator& Y, Operator& Z )
           double occnat_l = ket_kl.oq->occ_nat;
           for ( size_t j : iter_j.second )
           {
-            if (!Z.ThreeBody.IsKetInEMaxTruncations(ket_kl.p, ket_kl.q, j)) continue;
+            if (!Y3.IsOrbitIn3BodyEMaxTruncation(j)) continue;
+            // if (!Z.ThreeBody.IsKetInEMaxTruncations(ket_kl.p, ket_kl.q, j)) continue;
             Orbit& oj = Z.modelspace->GetOrbit(j);
             double occnat_j = oj.occ_nat;
             if ( (occnat_k*(1-occnat_k) * occnat_l*(1-occnat_l) * occnat_j*(1-occnat_j) ) < Z.modelspace->GetOccNat3Cut() ) continue;
@@ -3013,6 +3017,9 @@ void comm232ss( const Operator& X, const Operator& Y, Operator& Z )
       Orbit& oa = Z.modelspace->GetOrbit(a);
       Orbit& ob = Z.modelspace->GetOrbit(b);
       Orbit& oc = Z.modelspace->GetOrbit(c);
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(oa)) continue;
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(ob)) continue;
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(oc)) continue;
       double na = oa.occ;
       double nb = ob.occ;
       double nc = oc.occ;
@@ -3046,6 +3053,9 @@ void comm232ss( const Operator& X, const Operator& Y, Operator& Z )
       Orbit& oa = Z.modelspace->GetOrbit(a);
       Orbit& ob = Z.modelspace->GetOrbit(b);
       Orbit& oc = Z.modelspace->GetOrbit(c);
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(oa)) continue;
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(ob)) continue;
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(oc)) continue;
       double de_a = std::abs( 2*oa.n + oa.l - e_fermi[oa.tz2]);
       double de_b = std::abs( 2*ob.n + ob.l - e_fermi[ob.tz2]);
       double de_c = std::abs( 2*oc.n + oc.l - e_fermi[oc.tz2]);
@@ -3063,6 +3073,9 @@ void comm232ss( const Operator& X, const Operator& Y, Operator& Z )
         Orbit& oj = Z.modelspace->GetOrbit(j);
         Orbit& ok = Z.modelspace->GetOrbit(k);
         Orbit& ol = Z.modelspace->GetOrbit(l);
+        if (!Y3.IsOrbitIn3BodyEMaxTruncation(oj)) continue;
+        if (!Y3.IsOrbitIn3BodyEMaxTruncation(ok)) continue;
+        if (!Y3.IsOrbitIn3BodyEMaxTruncation(ol)) continue;
         double de_j = std::abs( 2*oj.n + oj.l - e_fermi[oj.tz2]);
         double de_k = std::abs( 2*ok.n + ok.l - e_fermi[ok.tz2]);
         double de_l = std::abs( 2*ol.n + ol.l - e_fermi[ol.tz2]);
@@ -3122,6 +3135,9 @@ void comm232ss( const Operator& X, const Operator& Y, Operator& Z )
       Orbit& oa = Z.modelspace->GetOrbit(a);
       Orbit& ob = Z.modelspace->GetOrbit(b);
       Orbit& oc = Z.modelspace->GetOrbit(c);
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(oa)) continue;
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(ob)) continue;
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(oc)) continue;
       int j2c = oc.j2;
       double jc = 0.5 * j2c;
       double occ_abc = abc_occ_list[ind_abc]; // TODO: we can probably incorporate that hat factor with the occupation factor
@@ -3155,6 +3171,9 @@ void comm232ss( const Operator& X, const Operator& Y, Operator& Z )
         Orbit& oj = Z.modelspace->GetOrbit(j);
         Orbit& ok = Z.modelspace->GetOrbit(k);
         Orbit& ol = Z.modelspace->GetOrbit(l);
+        if (!Y3.IsOrbitIn3BodyEMaxTruncation(oj)) continue;
+        if (!Y3.IsOrbitIn3BodyEMaxTruncation(ok)) continue;
+        if (!Y3.IsOrbitIn3BodyEMaxTruncation(ol)) continue;
         double ji = 0.5 * j2i;
         double jj = 0.5 * oj.j2;
 //        double jk = 0.5 * ok.j2;
@@ -3255,6 +3274,8 @@ void comm232ss( const Operator& X, const Operator& Y, Operator& Z )
       size_t j=bra.q;
       Orbit& oi = Z.modelspace->GetOrbit(i);
       Orbit& oj = Z.modelspace->GetOrbit(j);
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(oi)) continue;
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(oj)) continue;
       if ( imsrg3_valence_2b and  (oi.cvq!=1 or oj.cvq!=1 ) ) continue;
 
 //      auto& lobc_i = local_one_body_channels.at({oi.j2,oi.l%2,oi.tz2});
@@ -3276,6 +3297,8 @@ void comm232ss( const Operator& X, const Operator& Y, Operator& Z )
         size_t l = ket.q;
         Orbit& ok = Z.modelspace->GetOrbit(k);
         Orbit& ol = Z.modelspace->GetOrbit(l);
+        if (!Y3.IsOrbitIn3BodyEMaxTruncation(ok)) continue;
+        if (!Y3.IsOrbitIn3BodyEMaxTruncation(ol)) continue;
         int phase_ij = X.modelspace->phase( (oi.j2+oj.j2)/2-J);
         int phase_kl = X.modelspace->phase( (ok.j2+ol.j2)/2-J);
 

--- a/src/Commutator.cc
+++ b/src/Commutator.cc
@@ -2764,6 +2764,8 @@ void comm132ss( const Operator& X, const Operator& Y, Operator& Z )
       Ket& bra = tbc.GetKet(ibra);
       int i = bra.p;
       int j = bra.q;
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(i)) continue;
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(j)) continue;
       int ei = 2*bra.op->n + bra.op->l;
       int ej = 2*bra.oq->n + bra.oq->l;
       double d_ei = std::abs(ei - e_fermi[bra.op->tz2]);
@@ -2775,6 +2777,8 @@ void comm132ss( const Operator& X, const Operator& Y, Operator& Z )
         Ket& ket = tbc.GetKet(iket);
         int k = ket.p;
         int l = ket.q;
+        if (!Y3.IsOrbitIn3BodyEMaxTruncation(k)) continue;
+        if (!Y3.IsOrbitIn3BodyEMaxTruncation(l)) continue;
         int ek = 2*ket.op->n + ket.op->l;
         int el = 2*ket.oq->n + ket.oq->l;
         double d_ek = std::abs( ek - e_fermi[ket.op->tz2]);
@@ -2787,6 +2791,7 @@ void comm132ss( const Operator& X, const Operator& Y, Operator& Z )
         for (int a=0;a<norb;a++)
         {
           Orbit& oa = Z.modelspace->GetOrbit(a);
+          if (!Y3.IsOrbitIn3BodyEMaxTruncation(oa)) continue;
 
           int ea = 2*oa.n + oa.l;
           double d_ea = std::abs( ea - e_fermi.at(oa.tz2));
@@ -2809,6 +2814,8 @@ void comm132ss( const Operator& X, const Operator& Y, Operator& Z )
           for ( auto b : blist ) 
           {
             Orbit& ob = Z.modelspace->GetOrbit(b);
+            if (!Y3.IsOrbitIn3BodyEMaxTruncation(ob)) continue;
+
             int eb = 2*ob.n + ob.l;
             double d_eb = std::abs( eb - e_fermi[ob.tz2]);
             double occnat_b = ob.occ_nat;

--- a/src/Commutator.cc
+++ b/src/Commutator.cc
@@ -3494,6 +3494,8 @@ void comm232ss_new( const Operator& X, const Operator& Y, Operator& Z )
     std::map<std::array<int,3>,std::vector<size_t>>& local_one_body_channels,
     std::map<std::array<int,3>,std::vector<size_t>>& external_local_one_body_channels
   ) {
+    const auto tstart = omp_get_wtime();
+
     const auto& Y3 = Y.ThreeBody;
   for ( auto j : Z.modelspace->all_orbits )
   {
@@ -3506,6 +3508,7 @@ void comm232ss_new( const Operator& X, const Operator& Y, Operator& Z )
     if ( external_local_one_body_channels.find(obc) == external_local_one_body_channels.end() ) external_local_one_body_channels[obc] = {j};
     else external_local_one_body_channels[obc].push_back(j);
   }
+    Y.profiler.timer[__func__] += omp_get_wtime() - tstart;
   }
 
   void comm232_new_Populate1BChannel(
@@ -3518,6 +3521,8 @@ void comm232ss_new( const Operator& X, const Operator& Y, Operator& Z )
     std::map<std::array<int,3>,std::vector<std::array<size_t,4>>>& klj_list,
     std::map<std::array<int,3>,arma::mat>& ZMAT_list
   ) {
+    const auto tstart = omp_get_wtime();
+
     const auto& Y3 = Y.ThreeBody;
   size_t nkeys = obc_keys.size();
   for ( size_t ikey=0; ikey<nkeys; ikey++ )
@@ -3578,6 +3583,7 @@ void comm232ss_new( const Operator& X, const Operator& Y, Operator& Z )
     size_t dim_klj = klj_list[obc_key].size();
     ZMAT_list[obc_key] =  arma::mat(dim_i,dim_klj) ;
   }// for ikey
+    Y.profiler.timer[__func__] += omp_get_wtime() - tstart;
   }
 
   void comm232_new_Determine3BStatesIn1BChannel(
@@ -3588,6 +3594,8 @@ void comm232ss_new( const Operator& X, const Operator& Y, Operator& Z )
     std::vector<size_t>& abc_list,
     std::vector<double>& abc_occ_list
   ) {
+    const auto tstart = omp_get_wtime();
+
     const auto& Y3 = Y.ThreeBody;
     for (size_t i_kljJ=0; i_kljJ< klj_list.at(obc_key).size(); i_kljJ++ )
     {
@@ -3610,6 +3618,7 @@ void comm232ss_new( const Operator& X, const Operator& Y, Operator& Z )
       abc_list.push_back( i_kljJ );
       abc_occ_list.push_back( occupation_factor );
     }
+    Y.profiler.timer[__func__] += omp_get_wtime() - tstart;
   }
 
 
@@ -3623,6 +3632,8 @@ void comm232ss_new( const Operator& X, const Operator& Y, Operator& Z )
     size_t dim_klj,
     std::unordered_set<size_t>& kljJJ_needed
   ) {
+    const auto tstart_parallel = omp_get_wtime();
+
     const auto& Y3 = Y.ThreeBody;
     // Set up one set per thread
     int num_threads = omp_get_max_threads();
@@ -3691,12 +3702,18 @@ void comm232ss_new( const Operator& X, const Operator& Y, Operator& Z )
       }// for ind_klj
     }// for ind_abc
 
+    Y.profiler.timer[std::string(__func__) + " parallel"] += omp_get_wtime() - tstart_parallel;
+
+    const auto tstart_merge = omp_get_wtime();
+
     // Merge sets
     for (const auto& thread_safe_kljJJ : kljJJ_needed_threadsafe_vec) {
       for (const auto& el : thread_safe_kljJJ) {
         kljJJ_needed.insert(el);
       }
     }
+  
+    Y.profiler.timer[std::string(__func__) + " merge"] += omp_get_wtime() - tstart_merge;
   }
 
   void comm232_new_ComputeRequiredRecouplings(
@@ -3799,6 +3816,8 @@ void comm232ss_new( const Operator& X, const Operator& Y, Operator& Z )
     arma::mat& X3MAT,
     arma::mat& Y3MAT
   ) {
+    const auto tstart = omp_get_wtime();
+
     const auto& Y3 = Y.ThreeBody;
     const auto& X3 = X.ThreeBody;
 
@@ -3917,6 +3936,7 @@ void comm232ss_new( const Operator& X, const Operator& Y, Operator& Z )
         }// for twoJp
       }// for ind_klj
     }// for ind_abc
+    Y.profiler.timer[__func__] += omp_get_wtime() - tstart;
   }
 
   void comm232_new_Unpack2BResult(
@@ -3928,6 +3948,8 @@ void comm232ss_new( const Operator& X, const Operator& Y, Operator& Z )
     const std::map<std::array<int,3>,arma::mat>& ZMAT_list,
     Operator& Z
     ) {
+    const auto tstart = omp_get_wtime();
+
       const auto& Y3 = Y.ThreeBody;
   int hermX = X.IsHermitian() ? 1 : -1;
   int hermY = Y.IsHermitian() ? 1 : -1;
@@ -4019,6 +4041,7 @@ void comm232ss_new( const Operator& X, const Operator& Y, Operator& Z )
       }//for iket
     }//for ibra
   }// for ch
+    Y.profiler.timer[__func__] += omp_get_wtime() - tstart;
   }
 
 

--- a/src/Commutator.cc
+++ b/src/Commutator.cc
@@ -7,9 +7,11 @@
 #include "armadillo"
 #include "PhysicalConstants.hh" // for SQRT2
 #include "AngMom.hh"
+#include <cstddef>
 #include <map>
 #include <deque>
 #include <array>
+#include <unordered_map>
 #include <vector>
 #include <string>
 #include <iostream>
@@ -202,7 +204,7 @@ Operator CommutatorScalarScalar( const Operator& X, const Operator& Y)
        if ( comm_term_on["comm133ss"])
        {
         //important for suppressing off-diagonal H3
-        std::cout << " comm133 " << std::endl;
+        // std::cout << " comm133 " << std::endl;
         comm133ss(X, Y, Z);  // scales as n^7, but really more like n^6
        }
    if ((X.Norm() > threebody_threshold) || (Y.Norm() > threebody_threshold)) 
@@ -212,21 +214,21 @@ Operator CommutatorScalarScalar( const Operator& X, const Operator& Y)
        if ( comm_term_on["comm330ss"] )
        {
         // This gets the perturbative energy from the induced 3 body
-        std::cout << " comm330 " << std::endl;
+        // std::cout << " comm330 " << std::endl;
         comm330ss(X, Y, Z); // scales as n^6
        }
 
        if ( comm_term_on["comm331ss"])
        {
         //Maybe not so important, but I think relatively cheap
-        std::cout << " comm331 " << std::endl;
+        // std::cout << " comm331 " << std::endl;
         comm331ss(X, Y, Z); // scales as n^7
        }
 
        if ( comm_term_on["comm223ss"])
        {
         // This one is essential. If it's not here, then there are no induced 3 body terms
-        std::cout << " comm223 " << std::endl;
+        // std::cout << " comm223 " << std::endl;
         comm223ss(X, Y, Z); // scales as n^7
 //       comm223ss_debug(X, Y, Z); // scales as n^7
        }
@@ -235,14 +237,14 @@ Operator CommutatorScalarScalar( const Operator& X, const Operator& Y)
        if ( comm_term_on["comm231ss"])
        {
         // Demonstrated that this can have some effect
-        std::cout << " comm231 " << std::endl;
+        // std::cout << " comm231 " << std::endl;
         comm231ss(X, Y, Z);  // scales as n^6
        }
 
        if ( comm_term_on["comm132ss"])
        {
         //no demonstrated effect yet, but it's cheap
-        std::cout << " comm132 " << std::endl;
+        // std::cout << " comm132 " << std::endl;
         comm132ss(X, Y, Z); // scales as n^6
        }
 
@@ -250,7 +252,8 @@ Operator CommutatorScalarScalar( const Operator& X, const Operator& Y)
        {
         //one of the two most important IMSRG(3) terms
         std::cout << " comm232 " << std::endl;
-        comm232ss(X, Y, Z);   // this is the slowest n^7 term
+        // comm232ss(X, Y, Z);   // this is the slowest n^7 term
+        comm232ss_new(X, Y, Z);   // this is the slowest n^7 term
 //       comm232ss_debug(X, Y, Z);   // this is the slowest n^7 term
        }
 
@@ -277,7 +280,7 @@ Operator CommutatorScalarScalar( const Operator& X, const Operator& Y)
        {
         // This one is super slow too. It involves 9js
         // mat mult makes everything better!
-        std::cout << " comm233_ph " << std::endl;
+        // std::cout << " comm233_ph " << std::endl;
         comm233_phss(X, Y, Z);
 //       comm233_phss_debug(X, Y, Z);
        }
@@ -285,14 +288,14 @@ Operator CommutatorScalarScalar( const Operator& X, const Operator& Y)
        if ( comm_term_on["comm332_ppph_hhhpss"])
        {
         //not too bad, though naively n^8
-        std::cout << " comm332_ppph_hhhp " << std::endl;
+        // std::cout << " comm332_ppph_hhhp " << std::endl;
         comm332_ppph_hhhpss(X, Y, Z);
        }
 
        if ( comm_term_on["comm332_pphhss"])
        {
         //naively n^8, but reasonably fast when implemented as a mat mult
-        std::cout << " comm332_pphh " << std::endl;
+        // std::cout << " comm332_pphh " << std::endl;
         comm332_pphhss(X, Y, Z);
 //       comm332_pphhss_debug(X, Y, Z);
        }
@@ -300,7 +303,7 @@ Operator CommutatorScalarScalar( const Operator& X, const Operator& Y)
        if ( comm_term_on["comm333_ppp_hhhss"])
        {
         //naively n^9 but pretty fast as a mat mult
-        std::cout << " comm333_ppp_hhhss " << std::endl;
+        // std::cout << " comm333_ppp_hhhss " << std::endl;
         comm333_ppp_hhhss(X, Y, Z);
        }
 
@@ -308,7 +311,7 @@ Operator CommutatorScalarScalar( const Operator& X, const Operator& Y)
        {
         //This one works, but it's incredibly slow.  naively n^9.
        //Much improvement by going to mat mult
-        std::cout << " comm333_pph_hhpss " << std::endl;
+        // std::cout << " comm333_pph_hhpss " << std::endl;
         comm333_pph_hhpss(X, Y, Z);
 //       comm333_pph_hhpss_debug(X, Y, Z);
        }
@@ -2850,10 +2853,6 @@ void comm132ss( const Operator& X, const Operator& Y, Operator& Z )
 }
 
 
-
-
-
-
 //*****************************************************************************************
 //
 //  |         |
@@ -3352,7 +3351,581 @@ void comm232ss( const Operator& X, const Operator& Y, Operator& Z )
   Z.profiler.timer[__func__] += omp_get_wtime() - tstart;
 }
 
+namespace {
+static inline size_t Hash_comm232_key2(const std::array<size_t, 5> &kljJJ) {
+  return kljJJ[0] + (kljJJ[1] << 8) + (kljJJ[2] << 16) + (kljJJ[3] << 24) +
+         (kljJJ[4] << 32);
+};
 
+static inline std::array<size_t, 5> Unhash_comm232_key2(size_t hash) {
+  std::array<size_t, 5> kljJJ;
+  size_t mask = 0xFF;
+  for (size_t i = 0; i < 5; i += 1) {
+      kljJJ[i] = (hash >> i * 8) & mask;
+  }
+  return kljJJ;
+};
+} // namespace
+
+//*****************************************************************************************
+//
+//  |         |
+// i|        j|     Uncoupled expression:
+//  *~~[X]~*  |         Z_ijkl = -1/2 sum_abc (nanbn`c+n`an`bnc) ( (1-Pij) X_icab * Y_abjklc - (1-Pkl) Yijcabl * Xabkc )
+// a|    b/c\ |
+//  |    /   \|
+//  *~~[Y]~~~~*      Coupled expression:
+//  |   |              Z_{ijkl}^{J} = -1/2 sum_abc (nanbn`c+n`an`bnc) sum_J'J" (2J'+1)(2J"+1)/sqrt(2J+1) (-1)^{2J"+J'-J}
+// k|  l|                           *  [   (1 - (-1)^{i+j-J}Pij) (-1)^{j-c} { j  J" J' } X_icab^{J'} * Y_{abjklc}^{J'JJ"}    
+//                                                                          { c  i  J  }
+//                           
+//                                       -(1 - (-1)^{k+l-J}Pkl)  (-1)^{l-c} { l  J" J' } Y_{ijcabl}^{JJ'J"} * X_{abkc}^{J'}  ]
+//                                                                          { c  k  J  }
+//
+//   The factor 1/2 out front is absorbed by the fact that we only do the ordering a<=b  (need to deal carefully with a==b)
+//   
+//  For efficiency, we unfold this diagram to look like 
+//  |
+// i|
+//  *~~[X]~*
+//  |a  b / \c
+//  |    /   \
+//  *~~[Y]~~~*
+//  |   |    |
+//  |k  |l   |j
+//
+//  Verified with UnitTest
+//
+// This is the time hog of the n^7 scaling terms   (seems to be doing better...)
+// Now this is fine. The 223 commutator is taking all the time.
+void comm232ss_new( const Operator& X, const Operator& Y, Operator& Z )
+{
+  double tstart = omp_get_wtime();
+//  auto& X2 = X.TwoBody;
+  auto& X3 = X.ThreeBody;
+//  auto& Y2 = Y.TwoBody;
+  auto& Y3 = Y.ThreeBody;
+  auto& Z2 = Z.TwoBody;
+
+  bool x_has_3 = X3.IsAllocated();
+  bool y_has_3 = Y3.IsAllocated();
+
+  int hermX = X.IsHermitian() ? 1 : -1;
+  int hermY = Y.IsHermitian() ? 1 : -1;
+
+  std::map<int,double> e_fermi = Z.modelspace->GetEFermi();
+
+ // Hash for lookup
+//  auto Hash_comm232_key = [] ( std::array<size_t,5>& kljJJ ){  return kljJJ[0] + (kljJJ[1] << 8) + (kljJJ[2] << 16) + (kljJJ[3] << 24) + (kljJJ[4]<<32);};
+
+  size_t nch = Z.modelspace->GetNumberTwoBodyChannels();
+
+  // first, enumerate the one-body channels |i> => ji,parityi,tzi
+  std::map<std::array<int,3>,std::vector<size_t>> local_one_body_channels; //  maps {j,parity,tz} => vector of index_j 
+  std::map<std::array<int,3>,std::vector<size_t>> external_local_one_body_channels; //  maps {j,parity,tz} => vector of index_j 
+  comm232_new_Determine1BChannels(Z, Y, local_one_body_channels, external_local_one_body_channels);
+  
+  // next, figure out which three-body states |klj`> and |abc`> exist, make a list, and give them an
+  // index for where they'll sit in the matrix
+  std::map<std::array<int,3>,std::vector<std::array<size_t,4>>> klj_list; //  maps {j,parity,tz} => {kljJ}
+  std::map<std::array<int,3>,arma::mat> ZMAT_list; //  maps {j,parity,tz} => matrix <i|Z|klj`>
+
+  std::vector<std::array<int,3>> obc_keys;
+  for ( auto& iter_i : external_local_one_body_channels) obc_keys.push_back(iter_i.first);
+  size_t nkeys = obc_keys.size();
+
+  comm232_new_Populate1BChannel(Z, Y, e_fermi, local_one_body_channels, external_local_one_body_channels, obc_keys, klj_list, ZMAT_list);
+
+  Z.modelspace->PreCalculateSixJ(); // if this has already been done, this does nothing.
+  // This loop is what takes all the time.
+  // Outer loop over one-body quantum numbers, which also label the three-body pph states |klj`> and |abc`>
+//  #pragma omp parallel for schedule(dynamic,1) if (not Z.modelspace->scalar3b_transform_first_pass)
+  // #pragma omp parallel for schedule(dynamic,1) 
+  for ( size_t ikey=0; ikey<nkeys; ikey++ )
+  {
+
+    const auto& obc_key = obc_keys[ikey]; // this is an array {j2,parity,tz2}
+    int j2i = obc_key[0];
+    const std::vector<size_t>& obc_orbits = external_local_one_body_channels[obc_key]; // the orbits that have quantum numbers {j2,parity,tz2}
+    const auto& klj_list_i = klj_list[obc_key]; // list of 3-body pph stats |klj`> with quantum numbers {j2,parity,tz2}
+
+    std::vector<size_t> abc_list; // keep track of which klj states should go in the abc loop
+    std::vector<double> abc_occ_list;
+    comm232_new_Determine3BStatesIn1BChannel(Y, Z, klj_list, obc_key, abc_list, abc_occ_list);
+
+    size_t dim_i   = obc_orbits.size(); // how many sp states are in this jpt channel
+    size_t dim_klj = klj_list[obc_key].size(); // how many 3-body pph states in this jpt channel
+    size_t dim_abc = abc_list.size(); // how many 3-body states which contribute to the |abc`> sum
+
+
+    // Now allocate the matrices in this channel
+    arma::mat X2MAT(dim_i,   dim_abc, arma::fill::zeros);
+    arma::mat Y2MAT(dim_i,   dim_abc, arma::fill::zeros);
+    arma::mat X3MAT(dim_abc, dim_klj, arma::fill::zeros);
+    arma::mat Y3MAT(dim_abc, dim_klj, arma::fill::zeros);
+
+   //figure out which recouplings we'll need when filling the matrices
+    std::set<std::array<size_t,5>> kljJJ_needed; // we use a set to avoid repeats
+    comm232_new_GenerateRequiredRecouplings(Z, Y, abc_list, klj_list_i, e_fermi, dim_abc, dim_klj, kljJJ_needed);
+
+   // now compute the couplings once and store them in a hash table
+   std::vector<double> recoupling_cache; // a vector storing all the relevant recoupling info
+   std::unordered_map<size_t, size_t> recoupling_cache_lookup; // a lookup table so we can find the info easily
+   comm232_new_ComputeRequiredRecouplings(Y, kljJJ_needed, recoupling_cache, recoupling_cache_lookup);
+
+    // Now fill the matrices
+    comm232_new_FillMatrices(Z, X, Y, dim_abc, dim_i, dim_klj, j2i, x_has_3, y_has_3, abc_list, klj_list_i, e_fermi, abc_occ_list, obc_orbits, recoupling_cache, recoupling_cache_lookup, X2MAT, Y2MAT, X3MAT, Y3MAT);
+
+    // now we do the mat mult
+    ZMAT_list[obc_key] =  (  X2MAT * Y3MAT - Y2MAT * X3MAT  ) ;
+
+  }// for iter_i in local one body channels
+
+  // now we need to unpack all that mess and store it in Z
+  comm232_new_Unpack2BResult(X, Y, nch, external_local_one_body_channels, klj_list, ZMAT_list, Z);
+  Z.profiler.timer[__func__] += omp_get_wtime() - tstart;
+}
+
+  void comm232_new_Determine1BChannels(
+    const Operator& Z,
+    const Operator& Y,
+    std::map<std::array<int,3>,std::vector<size_t>>& local_one_body_channels,
+    std::map<std::array<int,3>,std::vector<size_t>>& external_local_one_body_channels
+  ) {
+    const auto& Y3 = Y.ThreeBody;
+  for ( auto j : Z.modelspace->all_orbits )
+  {
+    Orbit& oj = Z.modelspace->GetOrbit(j);
+    if (!Y3.IsOrbitIn3BodyEMaxTruncation(oj)) continue;
+    std::array<int,3> obc = {oj.j2,oj.l%2,oj.tz2};
+    if ( local_one_body_channels.find(obc) == local_one_body_channels.end() ) local_one_body_channels[obc] = {j};
+    else local_one_body_channels[obc].push_back(j);
+    if ( imsrg3_valence_2b and ( oj.cvq!=1)   ) continue;
+    if ( external_local_one_body_channels.find(obc) == external_local_one_body_channels.end() ) external_local_one_body_channels[obc] = {j};
+    else external_local_one_body_channels[obc].push_back(j);
+  }
+  }
+
+  void comm232_new_Populate1BChannel(
+    const Operator& Z,
+    const Operator& Y,
+    const std::map<int,double>& e_fermi,
+    const std::map<std::array<int,3>,std::vector<size_t>>& local_one_body_channels,
+    const std::map<std::array<int,3>,std::vector<size_t>>& external_local_one_body_channels,
+    const std::vector<std::array<int,3>>& obc_keys,
+    std::map<std::array<int,3>,std::vector<std::array<size_t,4>>>& klj_list,
+    std::map<std::array<int,3>,arma::mat>& ZMAT_list
+  ) {
+    const auto& Y3 = Y.ThreeBody;
+  size_t nkeys = obc_keys.size();
+  for ( size_t ikey=0; ikey<nkeys; ikey++ )
+  {
+    auto& obc_key = obc_keys[ikey];
+    const std::vector<size_t>& obc_orbits = external_local_one_body_channels.at(obc_key);
+    int j2i = obc_key[0];
+    int parityi = obc_key[1];
+    int tz2i = obc_key[2];
+    klj_list[obc_key] = {};
+    auto& klj_list_i = klj_list[obc_key];
+
+    for ( auto& iter_j : local_one_body_channels )
+    {
+      int j2j = iter_j.first[0];
+      int parityj = iter_j.first[1];
+      int tz2j = iter_j.first[2];
+
+      int Jkl_min = std::abs(j2i-j2j)/2;
+      int Jkl_max = (j2i+j2j)/2;
+      int Tzkl = (tz2i + tz2j)/2;
+      int paritykl = (parityi+parityj)%2;
+      for ( int Jkl = Jkl_min; Jkl<=Jkl_max; Jkl++)
+      {
+
+        size_t ch_kl = Z.modelspace->GetTwoBodyChannelIndex(Jkl, paritykl, Tzkl);
+        TwoBodyChannel& tbc_kl = Z.modelspace->GetTwoBodyChannel(ch_kl);
+        size_t nkets_kl = tbc_kl.GetNumberKets();
+        for ( size_t iket_kl=0; iket_kl<nkets_kl; iket_kl++)
+        {
+          Ket& ket_kl = tbc_kl.GetKet(iket_kl);
+          if (!Y3.IsOrbitIn3BodyEMaxTruncation(ket_kl.p)) continue;
+          if (!Y3.IsOrbitIn3BodyEMaxTruncation(ket_kl.q)) continue;
+          int e_k = 2*ket_kl.op->n + ket_kl.op->l;
+          int e_l = 2*ket_kl.oq->n + ket_kl.oq->l;
+          if ( (e_k + e_l) > Z.modelspace->GetE3max()) continue;
+          double de_k = std::abs(e_k - e_fermi.at(ket_kl.op->tz2));
+          double de_l = std::abs(e_l - e_fermi.at(ket_kl.oq->tz2));
+          if ( (de_k + de_l) > Z.modelspace->GetdE3max() ) continue;
+          double occnat_k = ket_kl.op->occ_nat;
+          double occnat_l = ket_kl.oq->occ_nat;
+          for ( size_t j : iter_j.second )
+          {
+            if (!Y3.IsOrbitIn3BodyEMaxTruncation(j)) continue;
+            // if (!Z.ThreeBody.IsKetInEMaxTruncations(ket_kl.p, ket_kl.q, j)) continue;
+            Orbit& oj = Z.modelspace->GetOrbit(j);
+            double occnat_j = oj.occ_nat;
+            if ( (occnat_k*(1-occnat_k) * occnat_l*(1-occnat_l) * occnat_j*(1-occnat_j) ) < Z.modelspace->GetOccNat3Cut() ) continue;
+
+            klj_list_i.push_back( { ket_kl.p, ket_kl.q, j, (size_t)tbc_kl.J } );
+
+          }// for j
+        }// for iket_kl
+      }// for Jkl
+    }// for iter_j in local one body channels
+
+    size_t dim_i   = obc_orbits.size(); // how many sp states are in this jpt channel
+    size_t dim_klj = klj_list[obc_key].size();
+    ZMAT_list[obc_key] =  arma::mat(dim_i,dim_klj) ;
+  }// for ikey
+  }
+
+  void comm232_new_Determine3BStatesIn1BChannel(
+    const Operator& Y,
+    const Operator& Z,
+    const std::map<std::array<int,3>,std::vector<std::array<size_t,4>>>& klj_list,
+    std::array<int, 3> obc_key,
+    std::vector<size_t>& abc_list,
+    std::vector<double>& abc_occ_list
+  ) {
+    const auto& Y3 = Y.ThreeBody;
+    for (size_t i_kljJ=0; i_kljJ< klj_list.at(obc_key).size(); i_kljJ++ )
+    {
+      auto& kljJ = klj_list.at(obc_key)[i_kljJ];
+      size_t a = kljJ[0];
+      size_t b = kljJ[1];
+      size_t c = kljJ[2];
+      Orbit& oa = Z.modelspace->GetOrbit(a);
+      Orbit& ob = Z.modelspace->GetOrbit(b);
+      Orbit& oc = Z.modelspace->GetOrbit(c);
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(oa)) continue;
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(ob)) continue;
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(oc)) continue;
+      double na = oa.occ;
+      double nb = ob.occ;
+      double nc = oc.occ;
+      double occupation_factor = na*nb*(1-nc) + (1-na)*(1-nb)*nc;
+      if (std::abs(occupation_factor)<1e-6) continue;
+      if (a==b) occupation_factor *=0.5;  // we sum a<=b, and drop the 1/2, but we still need the 1/2 for a==b
+      abc_list.push_back( i_kljJ );
+      abc_occ_list.push_back( occupation_factor );
+    }
+  }
+
+
+  void comm232_new_GenerateRequiredRecouplings(const Operator& Z, const Operator& Y, const std::vector<size_t>& abc_list, const std::vector<std::array<size_t, 4>>& klj_list_i, const std::map<int, double>& e_fermi, size_t dim_abc, size_t dim_klj, std::set<std::array<size_t, 5>>& kljJJ_needed) {
+    const auto& Y3 = Y.ThreeBody;
+    for (size_t ind_abc=0; ind_abc<dim_abc; ind_abc++) 
+    {
+      auto& abcJ = klj_list_i[ abc_list[ind_abc] ];
+      size_t a = abcJ[0];
+      size_t b = abcJ[1];
+      size_t c = abcJ[2];
+      int Jab  = abcJ[3];
+      Orbit& oa = Z.modelspace->GetOrbit(a);
+      Orbit& ob = Z.modelspace->GetOrbit(b);
+      Orbit& oc = Z.modelspace->GetOrbit(c);
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(oa)) continue;
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(ob)) continue;
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(oc)) continue;
+      double de_a = std::abs( 2*oa.n + oa.l - e_fermi.at(oa.tz2));
+      double de_b = std::abs( 2*ob.n + ob.l - e_fermi.at(ob.tz2));
+      double de_c = std::abs( 2*oc.n + oc.l - e_fermi.at(oc.tz2));
+//      double occnat_a = oa.occ_nat;
+//      double occnat_b = ob.occ_nat;
+      double occnat_c = oc.occ_nat;
+      int j2c = oc.j2;
+      for (size_t ind_klj=0; ind_klj<dim_klj; ind_klj++)
+      {
+        auto& kljJ = klj_list_i[ ind_klj ];
+        size_t k = kljJ[0];
+        size_t l = kljJ[1];
+        size_t j = kljJ[2];
+        int Jkl = kljJ[3];
+        Orbit& oj = Z.modelspace->GetOrbit(j);
+        Orbit& ok = Z.modelspace->GetOrbit(k);
+        Orbit& ol = Z.modelspace->GetOrbit(l);
+        if (!Y3.IsOrbitIn3BodyEMaxTruncation(oj)) continue;
+        if (!Y3.IsOrbitIn3BodyEMaxTruncation(ok)) continue;
+        if (!Y3.IsOrbitIn3BodyEMaxTruncation(ol)) continue;
+        double de_j = std::abs( 2*oj.n + oj.l - e_fermi.at(oj.tz2));
+        double de_k = std::abs( 2*ok.n + ok.l - e_fermi.at(ok.tz2));
+        double de_l = std::abs( 2*ol.n + ol.l - e_fermi.at(ol.tz2));
+//        double occnat_j = oj.occ_nat;
+        double occnat_k = ok.occ_nat;
+        double occnat_l = ol.occ_nat;
+        if ( (de_k + de_l + de_c) > Z.modelspace->GetdE3max() ) continue; 
+        if ( (de_a + de_b + de_j) > Z.modelspace->GetdE3max() ) continue;
+        if ( (occnat_k*(1-occnat_k) * occnat_l*(1-occnat_l) * occnat_c*(1-occnat_c) ) < Z.modelspace->GetOccNat3Cut() ) continue;
+        if ( imsrg3_no_qqq and ( (ok.cvq+ol.cvq+oc.cvq)>5 or (oa.cvq+ob.cvq+oj.cvq)>5)) continue;
+        if ( imsrg3_valence_2b and ( ok.cvq!=1  or ol.cvq!=1  or oj.cvq!=1) ) continue;
+        int twoJp_min = std::max( std::abs(2*Jab - oj.j2), std::abs(2*Jkl-j2c));
+        int twoJp_max = std::min( 2*Jab + oj.j2, 2*Jkl+j2c);
+        for (int twoJp=twoJp_min; twoJp<=twoJp_max; twoJp+=2)
+        {
+           kljJJ_needed.insert({k,l,c,(size_t)Jkl,(size_t)twoJp});
+           kljJJ_needed.insert({a,b,j,(size_t)Jab,(size_t)twoJp});
+        }// for twoJp
+      }// for ind_klj
+    }// for ind_abc
+  }
+
+  void comm232_new_ComputeRequiredRecouplings(const Operator& Y, const std::set<std::array<size_t, 5>>& kljJJ_needed, std::vector<double>& recoupling_cache, std::unordered_map<size_t, size_t>& recoupling_cache_lookup) {
+
+   for ( auto kljJJ : kljJJ_needed )
+   {
+     size_t k = kljJJ[0];
+     size_t l = kljJJ[1];
+     size_t j = kljJJ[2];
+     size_t Jkl = kljJJ[3];
+     size_t twoJp = kljJJ[4];
+     size_t hash = Hash_comm232_key2( kljJJ );
+
+     if (!Y.ThreeBody.IsKetValid(Jkl, twoJp, k, l, j)) continue;
+     std::vector<size_t> iketlist;
+     std::vector<double> recouplelist;
+     size_t ch_check = Y.ThreeBody.GetKetIndex_withRecoupling( Jkl, twoJp, k, l, j, iketlist, recouplelist) ;
+     size_t listsize = iketlist.size();
+     recoupling_cache_lookup[hash] = recoupling_cache.size();
+     recoupling_cache.push_back(ch_check);
+     recoupling_cache.push_back(listsize);
+     for (size_t ik : iketlist) recoupling_cache.push_back(ik); // Store the size_t (an unsigned int) as a double. I hope this doesn't cause problems...
+     for (double rec : recouplelist) recoupling_cache.push_back( rec);// Point to where this element lives in the vector
+   }
+  }
+
+  void comm232_new_FillMatrices(const Operator& Z, const Operator& X, const Operator Y, size_t dim_abc, size_t dim_i, size_t dim_klj, 
+    int j2i,
+    bool x_has_3,
+    bool y_has_3,
+    const std::vector<size_t>& abc_list,
+    const std::vector<std::array<size_t, 4>>& klj_list_i,
+    const std::map<int, double>& e_fermi,
+    const std::vector<double>& abc_occ_list,
+    const std::vector<size_t>& obc_orbits,
+    const std::vector<double>& recoupling_cache,
+    const std::unordered_map<size_t, size_t>& recoupling_cache_lookup,
+    arma::mat& X2MAT,
+    arma::mat& Y2MAT,
+    arma::mat& X3MAT,
+    arma::mat& Y3MAT
+  ) {
+    const auto& Y3 = Y.ThreeBody;
+    const auto& X3 = X.ThreeBody;
+    for (size_t ind_abc=0; ind_abc<dim_abc; ind_abc++) // rows of X2MAT
+    {
+
+      auto& abcJ = klj_list_i[ abc_list[ind_abc] ];
+      size_t a = abcJ[0];
+      size_t b = abcJ[1];
+      size_t c = abcJ[2];
+      int Jab  = abcJ[3];
+      Orbit& oa = Z.modelspace->GetOrbit(a);
+      Orbit& ob = Z.modelspace->GetOrbit(b);
+      Orbit& oc = Z.modelspace->GetOrbit(c);
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(oa)) continue;
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(ob)) continue;
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(oc)) continue;
+      int j2c = oc.j2;
+      double jc = 0.5 * j2c;
+      double occ_abc = abc_occ_list[ind_abc]; // TODO: we can probably incorporate that hat factor with the occupation factor
+
+      double de_a = std::abs( 2*oa.n + oa.l - e_fermi.at(oa.tz2));
+      double de_b = std::abs( 2*ob.n + ob.l - e_fermi.at(ob.tz2));
+      double de_c = std::abs( 2*oc.n + oc.l - e_fermi.at(oc.tz2));
+      double occnat_a = oa.occ_nat;
+      double occnat_b = ob.occ_nat;
+      double occnat_c = oc.occ_nat;
+
+      // fill the 2 body part
+      for (size_t ind_i=0; ind_i<dim_i; ind_i++)// ind_i indexes the list of sp states in this one body channel. columns of X2MAT
+      {
+        size_t i = obc_orbits[ind_i]; // i is the orbit index as per ModelSpace
+
+        X2MAT(ind_i,ind_abc) = -sqrt( (2*Jab+1.)) * occ_abc*  X.TwoBody.GetTBME_J(Jab,c,i,a,b);
+        Y2MAT(ind_i,ind_abc) = -sqrt( (2*Jab+1.)) * occ_abc*  Y.TwoBody.GetTBME_J(Jab,c,i,a,b);
+      }// for ind_i
+
+
+      // now the 3 body part
+      for (size_t ind_klj=0; ind_klj<dim_klj; ind_klj++)
+      {
+        // <abi Jab twoJ | X | klc Jkl twoJ >
+        auto& kljJ = klj_list_i[ ind_klj ];
+        size_t k = kljJ[0];
+        size_t l = kljJ[1];
+        size_t j = kljJ[2];
+        int Jkl = kljJ[3];
+        Orbit& oj = Z.modelspace->GetOrbit(j);
+        Orbit& ok = Z.modelspace->GetOrbit(k);
+        Orbit& ol = Z.modelspace->GetOrbit(l);
+        if (!Y3.IsOrbitIn3BodyEMaxTruncation(oj)) continue;
+        if (!Y3.IsOrbitIn3BodyEMaxTruncation(ok)) continue;
+        if (!Y3.IsOrbitIn3BodyEMaxTruncation(ol)) continue;
+        double ji = 0.5 * j2i;
+        double jj = 0.5 * oj.j2;
+//        double jk = 0.5 * ok.j2;
+//        double jl = 0.5 * ol.j2;
+
+        double de_j = std::abs( 2*oj.n + oj.l - e_fermi.at(oj.tz2));
+        double de_k = std::abs( 2*ok.n + ok.l - e_fermi.at(ok.tz2));
+        double de_l = std::abs( 2*ol.n + ol.l - e_fermi.at(ol.tz2));
+        double occnat_j = oj.occ_nat;
+        double occnat_k = ok.occ_nat;
+        double occnat_l = ol.occ_nat;
+        // Are these checks redundant?
+        if ( (de_a + de_b + de_j) > Z.modelspace->GetdE3max() ) continue;
+        if ( (de_k + de_l + de_c) > Z.modelspace->GetdE3max() ) continue;
+        if ( (occnat_a*(1-occnat_a) * occnat_b*(1-occnat_b) * occnat_j*(1-occnat_j) ) < Z.modelspace->GetOccNat3Cut() ) continue;
+        if ( (occnat_k*(1-occnat_k) * occnat_l*(1-occnat_l) * occnat_c*(1-occnat_c) ) < Z.modelspace->GetOccNat3Cut() ) continue;
+        if ( imsrg3_no_qqq and ( (ok.cvq+ol.cvq+oc.cvq)>5 or (oa.cvq+ob.cvq+oj.cvq)>5)) continue;
+        if ( imsrg3_valence_2b and  (ok.cvq!=1 or ol.cvq!=1 or oj.cvq!=1) ) continue;
+        
+        int twoJp_min = std::max( std::abs(2*Jab - oj.j2), std::abs(2*Jkl-j2c));
+        int twoJp_max = std::min( 2*Jab + oj.j2, 2*Jkl+j2c);
+
+
+        for (int twoJp=twoJp_min; twoJp<=twoJp_max; twoJp+=2)
+        {
+            if (!Y.ThreeBody.IsKetValid(Jkl, twoJp, k, l, c)) continue;
+            if (!Y.ThreeBody.IsKetValid(Jab, twoJp, a, b, j)) continue;
+//           double sixj = X.modelspace->GetSixJ(Jkl,jj,ji,  Jab, jc, 0.5*twoJp );
+           double sixj = X.modelspace->GetSixJ(jj,ji,Jkl,   jc, 0.5*twoJp, Jab );
+
+           std::array<size_t,5> abjJJ = { a,b,j,(size_t)Jab,(size_t)twoJp} ;
+           std::array<size_t,5> klcJJ = { k,l,c,(size_t)Jkl,(size_t)twoJp} ;
+           size_t hash_abj = Hash_comm232_key2( abjJJ );
+           size_t hash_klc = Hash_comm232_key2( klcJJ );
+           size_t pointer_abj = recoupling_cache_lookup.at(hash_abj);
+           size_t pointer_klc = recoupling_cache_lookup.at(hash_klc);
+           size_t ch_check = recoupling_cache[pointer_abj];
+           size_t listsize_abj = recoupling_cache[pointer_abj+1];
+           size_t listsize_klc = recoupling_cache[pointer_klc+1];
+           
+           double xabjklc = 0;
+           double yabjklc = 0;
+           for ( size_t ilist_abj=0; ilist_abj<listsize_abj; ilist_abj++)
+           {
+             size_t ibra_abj = (size_t) recoupling_cache[pointer_abj+2+ilist_abj];
+             double recouple_bra =      recoupling_cache[pointer_abj+2+listsize_abj+ilist_abj];
+             for ( size_t ilist_klc=0; ilist_klc<listsize_klc; ilist_klc++)
+             {
+               size_t iket_klc = (size_t) recoupling_cache[pointer_klc+2+ilist_klc];
+               double recouple_ket =      recoupling_cache[pointer_klc+2+listsize_klc+ilist_klc];
+
+//               xabjklc += recouple_bra*recouple_ket * X3.GetME_pn_ch(ch_check,ch_check, ibra_abj, iket_klc );
+               if (x_has_3 ) xabjklc += recouple_bra*recouple_ket * X3.GetME_pn_ch(ch_check,ch_check, ibra_abj, iket_klc );
+               if (y_has_3 ) yabjklc += recouple_bra*recouple_ket * Y3.GetME_pn_ch(ch_check,ch_check, ibra_abj, iket_klc );
+             }
+           }
+
+           X3MAT(ind_abc, ind_klj) += (twoJp+1.)/sqrt(2*Jkl+1.) * sixj * xabjklc;
+           Y3MAT(ind_abc, ind_klj) += (twoJp+1.)/sqrt(2*Jkl+1.) * sixj * yabjklc;
+
+        }// for twoJp
+      }// for ind_klj
+    }// for ind_abc
+  }
+
+  void comm232_new_Unpack2BResult(
+    const Operator& X,
+    const Operator& Y,
+    size_t nch,
+    const std::map<std::array<int,3>,std::vector<size_t>>& external_local_one_body_channels,
+    const std::map<std::array<int,3>,std::vector<std::array<size_t,4>>>& klj_list,
+    const std::map<std::array<int,3>,arma::mat>& ZMAT_list,
+    Operator& Z
+    ) {
+      const auto& Y3 = Y.ThreeBody;
+  int hermX = X.IsHermitian() ? 1 : -1;
+  int hermY = Y.IsHermitian() ? 1 : -1;
+  auto& Z2 = Z.TwoBody;
+  #pragma omp parallel for schedule(dynamic,1)
+  for ( size_t ch=0; ch<nch; ch++)
+  {
+    TwoBodyChannel& tbc = Z.modelspace->GetTwoBodyChannel(ch);
+    size_t nkets = tbc.GetNumberKets();
+    size_t J = tbc.J;
+    for (size_t ibra=0; ibra<nkets; ibra++)
+    {
+      Ket& bra = tbc.GetKet(ibra);
+      size_t i=bra.p;
+      size_t j=bra.q;
+      Orbit& oi = Z.modelspace->GetOrbit(i);
+      Orbit& oj = Z.modelspace->GetOrbit(j);
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(oi)) continue;
+      if (!Y3.IsOrbitIn3BodyEMaxTruncation(oj)) continue;
+      if ( imsrg3_valence_2b and  (oi.cvq!=1 or oj.cvq!=1 ) ) continue;
+
+//      auto& lobc_i = local_one_body_channels.at({oi.j2,oi.l%2,oi.tz2});
+//      auto& lobc_j = local_one_body_channels.at({oj.j2,oj.l%2,oj.tz2});
+      auto& lobc_i = external_local_one_body_channels.at({oi.j2,oi.l%2,oi.tz2});
+      auto& lobc_j = external_local_one_body_channels.at({oj.j2,oj.l%2,oj.tz2});
+      size_t ind_i = std::distance( lobc_i.begin(),  std::find( lobc_i.begin(),lobc_i.end(), i ) );
+      size_t ind_j = std::distance( lobc_j.begin(),  std::find( lobc_j.begin(),lobc_j.end(), j ) );
+
+      auto& list_i = klj_list.at({oi.j2,oi.l%2,oi.tz2});
+      auto& list_j = klj_list.at({oj.j2,oj.l%2,oj.tz2});
+      auto& ZMat_i = ZMAT_list.at({oi.j2,oi.l%2,oi.tz2});
+      auto& ZMat_j = ZMAT_list.at({oj.j2,oj.l%2,oj.tz2});
+
+      for (size_t iket=ibra; iket<nkets; iket++)
+      {
+        Ket& ket = tbc.GetKet(iket);
+        size_t k = ket.p;
+        size_t l = ket.q;
+        Orbit& ok = Z.modelspace->GetOrbit(k);
+        Orbit& ol = Z.modelspace->GetOrbit(l);
+        if (!Y3.IsOrbitIn3BodyEMaxTruncation(ok)) continue;
+        if (!Y3.IsOrbitIn3BodyEMaxTruncation(ol)) continue;
+        int phase_ij = X.modelspace->phase( (oi.j2+oj.j2)/2-J);
+        int phase_kl = X.modelspace->phase( (ok.j2+ol.j2)/2-J);
+
+        if ( imsrg3_valence_2b and  (ok.cvq!=1 or ol.cvq!=1 ) ) continue;
+
+//        auto& lobc_k = local_one_body_channels.at({ok.j2,ok.l%2,ok.tz2});
+//        auto& lobc_l = local_one_body_channels.at({ol.j2,ol.l%2,ol.tz2});
+        auto& lobc_k = external_local_one_body_channels.at({ok.j2,ok.l%2,ok.tz2});
+        auto& lobc_l = external_local_one_body_channels.at({ol.j2,ol.l%2,ol.tz2});
+        size_t ind_k = std::distance( lobc_k.begin(),  std::find( lobc_k.begin(),lobc_k.end(), k ) );
+        size_t ind_l = std::distance( lobc_l.begin(),  std::find( lobc_l.begin(),lobc_l.end(), l ) );
+
+        auto& list_k = klj_list.at({ok.j2,ok.l%2,ok.tz2});
+        auto& list_l = klj_list.at({ol.j2,ol.l%2,ol.tz2});
+        auto& ZMat_k = ZMAT_list.at({ok.j2,ok.l%2,ok.tz2});
+        auto& ZMat_l = ZMAT_list.at({ol.j2,ol.l%2,ol.tz2});
+
+        std::array<size_t,4> key_klj = {k,l,j,J};
+        std::array<size_t,4> key_kli = {k,l,i,J};
+        std::array<size_t,4> key_ijk = {i,j,k,J};
+        std::array<size_t,4> key_ijl = {i,j,l,J};
+
+        size_t ind_klj = std::distance( list_i.begin(),  std::find( list_i.begin(),list_i.end(), key_klj ) );
+        size_t ind_kli = std::distance( list_j.begin(),  std::find( list_j.begin(),list_j.end(), key_kli ) );
+        size_t ind_ijl = std::distance( list_k.begin(),  std::find( list_k.begin(),list_k.end(), key_ijl ) );
+        size_t ind_ijk = std::distance( list_l.begin(),  std::find( list_l.begin(),list_l.end(), key_ijk ) );
+
+        if ( ind_klj == list_i.size()   or ind_kli==list_j.size() or ind_ijl==list_k.size() or ind_ijk==list_l.size() )   continue;
+
+//        std::cout << "   made it. ijkl = " << i << " " << j << " " << k << " " << l << " J = " << J <<  "  with corresponding indices "
+//                  << ind_i << " , " << ind_klj << "  " << ind_j << " , " << ind_kli << "  "
+//                  << ind_k << " , " << ind_ijl << "  " << ind_l << " , " << ind_ijk << "   "
+//                  << ZMat_i(ind_i, ind_klj) << " " << ZMat_j(ind_j,ind_kli) << " " << ZMat_k(ind_k, ind_ijl) << " " << ZMat_l(ind_l,ind_ijk)
+//                  << " the obc keys we used are : (" << oi.j2<< " " << oi.l%2 << " " << oi.tz2 << ")"
+//                  << "  ("                           << oj.j2<< " " << oj.l%2 << " " << oj.tz2 << ")"
+//                  << "  ("                           << ok.j2<< " " << ok.l%2 << " " << ok.tz2 << ")"
+//                  << "  ("                           << ol.j2<< " " << ol.l%2 << " " << ol.tz2 << ")"
+//                  << std::endl;
+
+
+        double zijkl =            ZMat_j(ind_j, ind_kli) - phase_ij * ZMat_i(ind_i, ind_klj) 
+                - hermX*hermY * ( ZMat_l(ind_l, ind_ijk) - phase_kl * ZMat_k(ind_k, ind_ijl) ) ;
+
+        // normalize the tbme
+        zijkl *= -1.0 / sqrt((1+bra.delta_pq())*(1+ket.delta_pq()));
+        Z2.AddToTBME(ch,ch,ibra,iket,zijkl);
+      }//for iket
+    }//for ibra
+  }// for ch
+  }
 
 
 

--- a/src/Commutator.hh
+++ b/src/Commutator.hh
@@ -118,6 +118,7 @@ namespace Commutator{
   void comm132ss( const Operator& X, const Operator& Y, Operator& Z ) ;           // implemented and tested.
   size_t Hash_comm232_key( std::array<size_t,5>& kljJJ );
   void comm232ss( const Operator& X, const Operator& Y, Operator& Z ) ;           // implemented and tested.
+  void comm232ss_new( const Operator& X, const Operator& Y, Operator& Z ) ;           // implemented and tested.
   void comm232ss_debug( const Operator& X, const Operator& Y, Operator& Z ) ;           // implemented and tested.
   void comm232ss_slow( const Operator& X, const Operator& Y, Operator& Z ) ;           // implemented and tested.
   void comm332_ppph_hhhpss( const Operator& X, const Operator& Y, Operator& Z ) ; // implemented and tested.
@@ -181,7 +182,75 @@ namespace Commutator{
   void prod111ss( const Operator& X, const Operator& Y, Operator& Z ) ; 
   void prod112ss( const Operator& X, const Operator& Y, Operator& Z ) ; 
 
+  void comm232_new_Determine1BChannels(
+    const Operator& Z,
+    const Operator& Y,
+    std::map<std::array<int,3>,std::vector<size_t>>& local_one_body_channels,
+    std::map<std::array<int,3>,std::vector<size_t>>& external_local_one_body_channels
+  );
 
+  void comm232_new_Populate1BChannel(
+    const Operator& Z,
+    const Operator& Y,
+    const std::map<int,double>& e_fermi,
+    const std::map<std::array<int,3>,std::vector<size_t>>& local_one_body_channels,
+    const std::map<std::array<int,3>,std::vector<size_t>>& external_local_one_body_channels,
+    const std::vector<std::array<int,3>>& obc_keys,
+    std::map<std::array<int,3>,std::vector<std::array<size_t,4>>>& klj_list,
+    std::map<std::array<int,3>,arma::mat>& ZMAT_list
+  );
+
+  void comm232_new_Determine3BStatesIn1BChannel(
+    const Operator& Y,
+    const Operator& Z,
+    const std::map<std::array<int,3>,std::vector<std::array<size_t,4>>>& klj_list,
+    std::array<int, 3> obc_key,
+    std::vector<size_t>& abc_list,
+    std::vector<double>& abc_occ_list
+  );
+
+  void comm232_new_GenerateRequiredRecouplings(
+    const Operator& Z,
+    const Operator& Y,
+    const std::vector<size_t>& abc_list,
+    const std::vector<std::array<size_t, 4>>& klj_list_i,
+    const std::map<int, double>& e_fermi,
+    size_t dim_abc,
+    size_t dim_klj,
+    std::set<std::array<size_t, 5>>& kljJJ_needed);
+
+  void comm232_new_ComputeRequiredRecouplings(
+    const Operator& Y,
+    const std::set<std::array<size_t, 5>>& kljJJ_needed,
+    std::vector<double>& recoupling_cache,
+    std::unordered_map<size_t, size_t>& recoupling_cache_lookup);
+
+  void comm232_new_FillMatrices(const Operator& Z, const Operator& X, const Operator Y, size_t dim_abc, size_t dim_i, size_t dim_klj, 
+    int j2i,
+    bool x_has_3,
+    bool y_has_3,
+    const std::vector<size_t>& abc_list,
+    const std::vector<std::array<size_t, 4>>& klj_list_i,
+    const std::map<int, double>& e_fermi,
+    const std::vector<double>& abc_occ_list,
+    const std::vector<size_t>& obc_orbits,
+    const std::vector<double>& recoupling_cache,
+    const std::unordered_map<size_t, size_t>& recoupling_cache_lookup,
+    arma::mat& X2MAT,
+    arma::mat& Y2MAT,
+    arma::mat& X3MAT,
+    arma::mat& Y3MAT
+  );
+
+  void comm232_new_Unpack2BResult(
+    const Operator& X,
+    const Operator& Y,
+    size_t nch,
+    const std::map<std::array<int,3>,std::vector<size_t>>& external_local_one_body_channels,
+    const std::map<std::array<int,3>,std::vector<std::array<size_t,4>>>& klj_list,
+    const std::map<std::array<int,3>,arma::mat>& ZMAT_list,
+    Operator& Z
+    );
 
 }
 

--- a/src/Commutator.hh
+++ b/src/Commutator.hh
@@ -26,6 +26,7 @@
 #include "ThreeLegME.hh"
 #include "armadillo"
 #include <map>
+#include <unordered_set>
 #include <deque>
 #include <array>
 #include <string>
@@ -217,11 +218,11 @@ namespace Commutator{
     const std::map<int, double>& e_fermi,
     size_t dim_abc,
     size_t dim_klj,
-    std::set<std::array<size_t, 5>>& kljJJ_needed);
+    std::unordered_set<size_t>& kljJJ_needed);
 
   void comm232_new_ComputeRequiredRecouplings(
     const Operator& Y,
-    const std::set<std::array<size_t, 5>>& kljJJ_needed,
+    const std::unordered_set<size_t>& kljJJ_needed,
     std::vector<double>& recoupling_cache,
     std::unordered_map<size_t, size_t>& recoupling_cache_lookup);
 

--- a/src/HartreeFock.cc
+++ b/src/HartreeFock.cc
@@ -1332,8 +1332,8 @@ ThreeBodyME HartreeFock::GetTransformed3B( Operator& OpIn )
   std::vector<size_t> chbra_list,chket_list;
   for ( auto& itmat : hf3bme.Get_ch_start() )
   {
-    chbra_list.push_back( itmat.first[0] );
-    chket_list.push_back( itmat.first[1] );
+    chbra_list.push_back( itmat.first.ch_bra );
+    chket_list.push_back( itmat.first.ch_ket );
   }
   size_t nch3 = chbra_list.size();
   #pragma omp parallel for schedule(dynamic,1)

--- a/src/IMSRGProfiler.cc
+++ b/src/IMSRGProfiler.cc
@@ -1,4 +1,5 @@
 #include "IMSRGProfiler.hh"
+#include <algorithm>
 #include <sys/time.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -81,10 +82,15 @@ void IMSRGProfiler::PrintTimes()
    
    std::cout << "====================== TIMES (s) ====================" << std::endl;
    std::cout.setf(std::ios::fixed);
+   size_t max_func_length = 40;
+   for ( auto it : timer ) {
+    max_func_length = std::max( it.first.size(), max_func_length);
+   }
+   max_func_length += 5;
    for ( auto it : timer )
    {
      int nfill = (int) (20 * std::min( 1.0, it.second / time_tot["real"]));
-     std::cout << std::setw(40) << std::left << it.first + ":  " << std::setw(12) << std::setprecision(5) << std::right << it.second;
+     std::cout << std::setw(max_func_length) << std::left << it.first + ":  " << std::setw(12) << std::setprecision(5) << std::right << it.second;
      std::cout << " (" << std::setw(4) << std::setprecision(1) << 100*it.second / time_tot["real"] << "%) |";
      for (int ifill=0; ifill<nfill; ifill++) std::cout << "*";
      for (int ifill=nfill; ifill<20; ifill++) std::cout << " ";

--- a/src/IMSRGSolver.cc
+++ b/src/IMSRGSolver.cc
@@ -318,7 +318,7 @@ void IMSRGSolver::Solve_magnus_euler()
 //      cumulative_error += EstimateStepError();
 
       if (magnus_adaptive){
-      bool backoff = (std::abs(FlowingOps[0].ZeroBody - saved_E) > 3 * std::abs(saved_MP2));
+      bool backoff = ((std::abs(saved_MP2) < 1e-4) && (std::abs(FlowingOps[0].GetMP2_Energy()) > std::abs(saved_MP2)));
       if (backoff) {
         ds *= ds_backoff_factor_;
       } else {

--- a/src/IMSRGSolver.cc
+++ b/src/IMSRGSolver.cc
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iomanip>
+#include <iostream>
 #include <string>
 #include <sstream>
 
@@ -251,95 +252,109 @@ void IMSRGSolver::Solve_magnus_euler()
 //   }
 
    Elast = H_0->ZeroBody;
-  double saved_E = FlowingOps[0].ZeroBody;
-  double saved_MP2 = FlowingOps[0].GetMP2_Energy();
    cumulative_error = 0;
     // Write details of the flow
    WriteFlowStatus(flowfile);
    WriteFlowStatus(std::cout);
 
-   for (istep=1;s<smax;++istep)
-   {
+   for (istep = 1; s < smax; ++istep) {
+     double saved_MP2 = FlowingOps[0].GetMP2_Energy();
+     if ((!in_backoff_phase_) && (std::abs(saved_MP2) < 1e-3)) {
+       in_backoff_phase_ = true;
+       std::cout << "Entering backoff phase.\n";
+     }
 
-      double norm_eta = Eta.Norm();
-      if (norm_eta < eta_criterion )
-      {
-        break;
-      }
-      double norm_omega = Omega.back().Norm();
-      if (norm_omega > omega_norm_max)
-      {
-//        if ( perturbative_triples )
-//        {
-//          GetPerturbativeTriples();
-////          pert_triples_this_omega = GetPerturbativeTriples();
-////          pert_triples_sum += pert_triples_this_omega;
-//        }
-        if (hunter_gatherer)
-        {
-          GatherOmega();
-        }
-        else
-        {
-          NewOmega();
-        }
-        norm_omega = 0;
-      }
-      // ds should never be more than 1, as this is over-rotating
-      // if (magnus_adaptive)
-      //    ds = std::min( std::min( std::min(norm_domega/norm_eta, norm_domega / norm_eta / (norm_omega+1.0e-9)), omega_norm_max/norm_eta), ds_max);
-      ds = std::min(ds,smax-s);
+     double norm_eta = Eta.Norm();
+     if (norm_eta < eta_criterion) {
+       break;
+     }
+     while (magnus_adaptive && (ds * norm_eta > M_PI_4)) {
+      double new_ds = ds * ds_backoff_factor_;
+      std::cout << "Backing off ds because ds * norm_eta > pi / 4: ds = " << ds << " -> " << new_ds << "\n";
+      ds = new_ds;
+     }
+     double norm_omega = Omega.back().Norm();
+     if (norm_omega > omega_norm_max) {
+       //        if ( perturbative_triples )
+       //        {
+       //          GetPerturbativeTriples();
+       ////          pert_triples_this_omega = GetPerturbativeTriples();
+       ////          pert_triples_sum += pert_triples_this_omega;
+       //        }
+       if (hunter_gatherer) {
+         GatherOmega();
+       } else {
+         NewOmega();
+       }
+       norm_omega = 0;
+     }
+     // ds should never be more than 1, as this is over-rotating
+     // if (magnus_adaptive)
+     //    ds = std::min( std::min( std::min(norm_domega/norm_eta, norm_domega /
+     //    norm_eta / (norm_omega+1.0e-9)), omega_norm_max/norm_eta), ds_max);
+     ds = std::min(ds, smax - s);
 
-      s += ds;
-      Eta *= ds; // Here's the Euler step.
+     s += ds;
+     Eta *= ds; // Here's the Euler step.
 
-      // accumulated generator (aka Magnus operator) exp(Omega) = exp(dOmega) * exp(Omega_last)
-      Omega.back() = Commutator::BCH_Product( Eta, Omega.back() );
- 
-//      std::cout << " " << __FILE__ << " line " << __LINE__ << "  calling Commutator::BCH_Transform" << std::endl;
-      // transformed Hamiltonian H_s = exp(Omega) H_0 exp(-Omega)
-      if ((Omega.size()+n_omega_written)<2)
-      {
-        FlowingOps[0] = Commutator::BCH_Transform( *H_0, Omega.back() );
-      }
-      else
-      {
-        FlowingOps[0] = Commutator::BCH_Transform( H_saved, Omega.back() );
-      }
+     // accumulated generator (aka Magnus operator) exp(Omega) = exp(dOmega) *
+     // exp(Omega_last)
+     Omega.back() = Commutator::BCH_Product(Eta, Omega.back());
 
-      if (norm_eta<1.0 and generator.GetType() == "shell-model-atan")
-      {
-        generator.SetDenominatorCutoff(1e-6);
-      }
+     //      std::cout << " " << __FILE__ << " line " << __LINE__ << "  calling
+     //      Commutator::BCH_Transform" << std::endl;
+     // transformed Hamiltonian H_s = exp(Omega) H_0 exp(-Omega)
+     if ((Omega.size() + n_omega_written) < 2) {
+       FlowingOps[0] = Commutator::BCH_Transform(*H_0, Omega.back());
+     } else {
+       FlowingOps[0] = Commutator::BCH_Transform(H_saved, Omega.back());
+     }
 
-//      if ( generator.GetType() == "rspace" ) { generator.SetRegulatorLength(s); };
-//      generator.Update(&FlowingOps[0],&Eta);
-      generator.Update(FlowingOps[0],Eta);
-//      cumulative_error += EstimateStepError();
+     if (norm_eta < 1.0 and generator.GetType() == "shell-model-atan") {
+       generator.SetDenominatorCutoff(1e-6);
+     }
 
-      if (magnus_adaptive){
-      bool backoff = ((std::abs(saved_MP2) < 1e-4) && (std::abs(FlowingOps[0].GetMP2_Energy()) > std::abs(saved_MP2)));
-      if (backoff) {
-        ds *= ds_backoff_factor_;
-      } else {
-        ds = std::min(ds_max, ds * ds_max_growth_factor_);
-      }
-      }
+     //      if ( generator.GetType() == "rspace" ) {
+     //      generator.SetRegulatorLength(s); };
+     //      generator.Update(&FlowingOps[0],&Eta);
+     generator.Update(FlowingOps[0], Eta);
+     //      cumulative_error += EstimateStepError();
 
-      // Write details of the flow
-      WriteFlowStatus(flowfile);
-      WriteFlowStatus(std::cout);
-      Elast = FlowingOps[0].ZeroBody;
+     if (magnus_adaptive) {
+       if (in_backoff_phase_) {
+         bool backoff =
+             (std::abs(FlowingOps[0].GetMP2_Energy()) > std::abs(saved_MP2));
+         if (backoff) {
+           double ds_new = ds * ds_backoff_factor_;
+           std::cout << "Backing off ds because of MP2 growth, ds = " << ds << " -> " << ds_new
+                     << "\n";
+           ds = ds_new;
+         }
+       } else {
+         double ds_new = std::min(ds_max, ds * ds_max_growth_factor_);
+         if (ds_new > ds) {
+           std::cout << "Growing ds, ds = " << ds << " -> " << ds_new << "\n";
+           ds = ds_new;
+         }
+       }
+     }
 
-//      Operator DHDS = Commutator::Commutator( Eta, FlowingOps[0] );
-//      size_t ch = FlowingOps[0].modelspace->GetTwoBodyChannelIndex(0,0,1);
-//      auto MAT  = FlowingOps[0].TwoBody.GetMatrix(ch,ch);
-//      auto dMAT  = DHDS.TwoBody.GetMatrix(ch,ch);
-//      std::cout << " ======>  " << MAT(0,0) << "     " << MAT(1,0) << "   " << MAT(2,0) << "  " << MAT(1,1) << " " << MAT(2,1) << "  " << MAT(2,2) << std::endl;
-//      std::cout << " ______>  " << dMAT(0,0) << "     " << dMAT(1,0) << "   " << dMAT(2,0) << "  " << dMAT(1,1) << " " << dMAT(2,1) << "  " << dMAT(2,2) << std::endl;
+     // Write details of the flow
+     WriteFlowStatus(flowfile);
+     WriteFlowStatus(std::cout);
+     Elast = FlowingOps[0].ZeroBody;
 
+     //      Operator DHDS = Commutator::Commutator( Eta, FlowingOps[0] );
+     //      size_t ch =
+     //      FlowingOps[0].modelspace->GetTwoBodyChannelIndex(0,0,1); auto MAT
+     //      = FlowingOps[0].TwoBody.GetMatrix(ch,ch); auto dMAT  =
+     //      DHDS.TwoBody.GetMatrix(ch,ch); std::cout << " ======>  " <<
+     //      MAT(0,0) << "     " << MAT(1,0) << "   " << MAT(2,0) << "  " <<
+     //      MAT(1,1) << " " << MAT(2,1) << "  " << MAT(2,2) << std::endl;
+     //      std::cout << " ______>  " << dMAT(0,0) << "     " << dMAT(1,0) << "
+     //      " << dMAT(2,0) << "  " << dMAT(1,1) << " " << dMAT(2,1) << "  " <<
+     //      dMAT(2,2) << std::endl;
    }
-
 }
 
 

--- a/src/IMSRGSolver.hh
+++ b/src/IMSRGSolver.hh
@@ -68,6 +68,11 @@ class IMSRGSolver
   double cumulative_error;
   double pert_triples_this_omega;
   double pert_triples_sum;
+  
+  // Per step, ds may not grow more than 1.2 times its previous value.
+  double ds_max_growth_factor_ = 1.2;
+  // When abs(H(s + ds) - H(s)) > abs(E_MP2(s)), ds will "back off" by this factor.
+  double ds_backoff_factor_ = 0.5;
 
 
   ~IMSRGSolver();

--- a/src/IMSRGSolver.hh
+++ b/src/IMSRGSolver.hh
@@ -71,8 +71,10 @@ class IMSRGSolver
   
   // Per step, ds may not grow more than 1.2 times its previous value.
   double ds_max_growth_factor_ = 1.2;
-  // When abs(H(s + ds) - H(s)) > abs(E_MP2(s)), ds will "back off" by this factor.
+  // When abs(E_MP2(s + ds)) > abs(E_MP2(s)), ds will "back off" by this factor.
   double ds_backoff_factor_ = 0.5;
+  // Flag to signal when we are in the backoff phase
+  bool in_backoff_phase_ = false;
 
 
   ~IMSRGSolver();

--- a/src/ThreeBodyME.cc
+++ b/src/ThreeBodyME.cc
@@ -1,5 +1,6 @@
 #include "ThreeBodyME.hh"
 //#include "ThreeBodyStorage_pn.hh"
+#include "ModelSpace.hh"
 #include "ThreeBodyStorage_iso.hh"
 #include "IMSRGProfiler.hh"
 #include "AngMom.hh"
@@ -363,6 +364,16 @@ bool ThreeBodyME::IsKetValid( int Jab_in, int twoJ, size_t a_in, size_t b_in, si
 bool ThreeBodyME::IsKetInEMaxTruncations(size_t a_in, size_t b_in, size_t c_in) const
 {
    return threebody_storage->IsKetInEMaxTruncations(a_in, b_in, c_in);
+}
+
+bool ThreeBodyME::IsOrbitIn3BodyEMaxTruncation(size_t a) const
+{
+   return threebody_storage->IsOrbitIn3BodyEMaxTruncation(a);
+}
+
+bool ThreeBodyME::IsOrbitIn3BodyEMaxTruncation(const Orbit& oa) const
+{
+   return threebody_storage->IsOrbitIn3BodyEMaxTruncation(oa);
 }
 
 size_t ThreeBodyME::GetKetIndex_withRecoupling( int Jab_in, int twoJ, size_t a_in, size_t b_in, size_t c_in, std::vector<size_t>& iket , std::vector<double>& recouple) const

--- a/src/ThreeBodyME.cc
+++ b/src/ThreeBodyME.cc
@@ -1,11 +1,13 @@
 #include "ThreeBodyME.hh"
 //#include "ThreeBodyStorage_pn.hh"
 #include "ModelSpace.hh"
+#include "ThreeBodyStorage.hh"
 #include "ThreeBodyStorage_iso.hh"
 #include "IMSRGProfiler.hh"
 #include "AngMom.hh"
 
 #include <omp.h>
+#include <unordered_map>
 
 
 // Keeps track of whether any ThreeBodyME has been allocated
@@ -254,8 +256,8 @@ void ThreeBodyME::TransformToPN()
   std::vector<size_t> chbra_list,chket_list;
   for (auto iter : TBS_pn->ch_start)
   {
-    chbra_list.push_back(iter.first[0]);
-    chket_list.push_back(iter.first[1]);
+    chbra_list.push_back(iter.first.ch_bra);
+    chket_list.push_back(iter.first.ch_ket);
   }
   size_t nch = chbra_list.size();
 //  std::cout << "BEGIN LOOP" << std::endl;
@@ -411,7 +413,7 @@ std::vector<ThreeBodyStorage::Permutation> ThreeBodyME::UniquePermutations( size
   return threebody_storage->UniquePermutations(a,b,c);
 }
 
-std::map<std::array<size_t,2>,size_t>& ThreeBodyME::Get_ch_start()
+std::unordered_map<ThreeBodyStorageChannel,size_t,ThreeBodyStorageChannelHash>& ThreeBodyME::Get_ch_start()
 {
   return threebody_storage->ch_start;
 }

--- a/src/ThreeBodyME.hh
+++ b/src/ThreeBodyME.hh
@@ -165,7 +165,7 @@ class ThreeBodyME
   bool Is_Isospin_Mode() const {return (threebody_storage->GetStorageMode() == "isospin");};
   bool IsAllocated() const {return threebody_storage->IsAllocated();};
 
-  std::map<std::array<size_t,2>,size_t>& Get_ch_start();
+  std::unordered_map<ThreeBodyStorageChannel,size_t,ThreeBodyStorageChannelHash>& Get_ch_start();
   std::vector<size_t>& Get_ch_dim();
 
   double Norm() const;

--- a/src/ThreeBodyME.hh
+++ b/src/ThreeBodyME.hh
@@ -141,6 +141,10 @@ class ThreeBodyME
   bool IsKetValid(int Jab, int twoJ, size_t a, size_t b, size_t c) const;
   // Check that a, b, c fulfill the emax truncations.
   bool IsKetInEMaxTruncations(size_t a, size_t b, size_t c) const;
+  // Check that orbit a fulfills the 3-body emax truncation.
+  bool IsOrbitIn3BodyEMaxTruncation(size_t a) const;
+  // Check that orbit a fulfills the 3-body emax truncation.
+  bool IsOrbitIn3BodyEMaxTruncation(const Orbit& oa) const;
   size_t GetKetIndex_withRecoupling( int Jab, int twoJ, size_t a, size_t b, size_t c, std::vector<size_t>& ibra, std::vector<double>& recouple) const ;
 
   // setter-getters

--- a/src/ThreeBodyStorage.cc
+++ b/src/ThreeBodyStorage.cc
@@ -204,9 +204,29 @@ bool ThreeBodyStorage::IsKetInEMaxTruncations(size_t a, size_t b, size_t c) cons
   return true;
 }
 
+bool ThreeBodyStorage::IsOrbitIn3BodyEMaxTruncation(size_t a) const 
+{
+  const Orbit& oa = modelspace->GetOrbit(a);
+
+  return IsOrbitIn3BodyEMaxTruncation(oa);
+}
+
+bool ThreeBodyStorage::IsOrbitIn3BodyEMaxTruncation(const Orbit& oa) const 
+{
+
+  int e_a = oa.n * 2 + oa.l;
+
+  // Check against emax 3-body cut.
+  return e_a <= modelspace->GetEMax3Body();
+}
+
 size_t ThreeBodyStorage::GetKetIndex_withRecoupling( int Jab_in, int twoJ, size_t a_in, size_t b_in, size_t c_in, std::vector<size_t>& iket , std::vector<double>& recouple) const
 {
   int a,b,c;
+  if (!IsKetInEMaxTruncations(a_in, b_in, c_in)) {
+    std::cout << "Warning: Accessing matrix element that is 0 by truncations.\n";
+    std::cout << a_in << ", " << b_in << ", " << c_in << "\n";
+  }
   Permutation recoupling_case = SortOrbits(a_in,b_in,c_in,a,b,c);
 
   int permutation_phase = PermutationPhase( recoupling_case );

--- a/src/ThreeBodyStorage.hh
+++ b/src/ThreeBodyStorage.hh
@@ -27,6 +27,30 @@
 #include <vector>
 #include <memory> // for shared_ptr
 
+namespace {
+  inline size_t hash_combine( size_t lhs, size_t rhs ) {
+    lhs ^= rhs + 0x9e3779b9 + (lhs << 6) + (lhs >> 2);
+    return lhs;
+  }
+}
+
+struct ThreeBodyStorageChannel {
+  size_t ch_bra = 0;
+  size_t ch_ket = 0;
+
+  ThreeBodyStorageChannel(size_t cbra, size_t cket) : ch_bra(cbra), ch_ket(cket) {}
+};
+
+inline bool operator==(const ThreeBodyStorageChannel& a, const ThreeBodyStorageChannel& b) {
+  return (a.ch_bra == b.ch_bra) && (a.ch_ket == b.ch_ket);
+}
+
+struct ThreeBodyStorageChannelHash {
+  size_t operator()(const ThreeBodyStorageChannel& ch) const {
+    return hash_combine(ch.ch_bra, ch.ch_ket);
+  }
+};
+
 
 // This is used by mutliple implementations.
 class OrbitIsospin
@@ -59,7 +83,7 @@ class ThreeBodyStorage
 
   bool is_allocated=false;
 
-  std::map<std::array<size_t,2>,size_t> ch_start;
+  std::unordered_map<ThreeBodyStorageChannel,size_t, ThreeBodyStorageChannelHash> ch_start;
   std::vector<size_t> ch_dim;
 
 

--- a/src/ThreeBodyStorage.hh
+++ b/src/ThreeBodyStorage.hh
@@ -151,6 +151,8 @@ class ThreeBodyStorage
   // Check that a, b, c fulfill certain truncations and restrictions.
   bool IsKetValid(int Jab, int twoJ, size_t a, size_t b, size_t c) const;
   bool IsKetInEMaxTruncations(size_t a, size_t b, size_t c) const;
+  bool IsOrbitIn3BodyEMaxTruncation(size_t a) const;
+  bool IsOrbitIn3BodyEMaxTruncation(const Orbit& oa) const;
   size_t GetKetIndex_withRecoupling( int Jab, int twoJ, size_t a, size_t b, size_t c, std::vector<size_t>& ibra, std::vector<double>& recouple) const ;
 
 

--- a/src/ThreeBodyStorage_pn.cc
+++ b/src/ThreeBodyStorage_pn.cc
@@ -1,5 +1,6 @@
 
 #include "AngMom.hh"
+#include "ThreeBodyStorage.hh"
 #include "ThreeBodyStorage_pn.hh"
 
 

--- a/src/boost_src/CMakeLists.txt
+++ b/src/boost_src/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_library(
+    IMSRGBoostZip
+    gzip.cpp
+    zlib.cpp
+)
+target_link_libraries(
+    IMSRGBoostZip
+    PUBLIC
+    Boost::boost
+    ZLIB::ZLIB
+)

--- a/src/half/CMakeLists.txt
+++ b/src/half/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_library(
+    HalfPrecision
+    INTERFACE
+)
+target_include_directories(
+    HalfPrecision
+    INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)

--- a/src/profiling/CMakeLists.txt
+++ b/src/profiling/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(comm232 comm232.cc)
+target_link_libraries(comm232 
+    IMSRG
+    Parameters
+    PhysicalConstants
+    Version
+)

--- a/src/profiling/comm232.cc
+++ b/src/profiling/comm232.cc
@@ -92,7 +92,9 @@ int main(int argc, char** argv)
   op3.ThreeBody.SwitchToPN_and_discard();
 
   for (int i = 0; i < num_comms; i+=1){
+    std::cout << "Evaluating commutator " << i << "\n";
     Commutator::comm232ss_new(op1, op2, op3);
+    std::cout << "Evaluated commutator " << i << "\n";
   }
 
 

--- a/src/profiling/comm232.cc
+++ b/src/profiling/comm232.cc
@@ -1,0 +1,102 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+///                                                  ____                                         ///
+///        _________________           _____________/   /\               _________________        ///
+///       /____/_____/_____/|         /____/_____/ /___/  \             /____/_____/_____/|       ///
+///      /____/_____/__G_ /||        /____/_____/|/   /\  /\           /____/_____/____ /||       ///
+///     /____/_____/__+__/|||       /____/_____/|/ G /  \/  \         /____/_____/_____/|||       ///
+///    |     |     |     ||||      |     |     |/___/   /\  /\       |     |     |     ||||       ///
+///    |  I  |  M  |     ||/|      |  I  |  M  /   /\  /  \/  \      |  I  |  M  |     ||/|       ///
+///    |_____|_____|_____|/||      |_____|____/ + /  \/   /\  /      |_____|_____|_____|/||       ///
+///    |     |     |     ||||      |     |   /___/   /\  /  \/       |     |     |     ||||       ///
+///    |  S  |  R  |     ||/|      |  S  |   \   \  /  \/   /        |  S  |  R  |  G  ||/|       ///
+///    |_____|_____|_____|/||      |_____|____\ __\/   /\  /         |_____|_____|_____|/||       ///
+///    |     |     |     ||||      |     |     \   \  /  \/          |     |     |     ||||       ///
+///    |     |  +  |     ||/       |     |  +  |\ __\/   /           |     |  +  |  +  ||/        ///
+///    |_____|_____|_____|/        |_____|_____|/\   \  /            |_____|_____|_____|/         ///
+///                                               \___\/                                          ///
+///                                                                                               ///
+///           imsrg++ : Interface for performing standard IMSRG calculations.                     ///
+///                     Usage is imsrg++  option1=value1 option2=value2 ...                       ///
+///                     To get a list of options, type imsrg++ help                               ///
+///                                                                                               ///
+///                                                      - Ragnar Stroberg 2016                   ///
+///                                                                                               ///
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////////////
+//    imsrg++.cc, part of  imsrg++
+//    Copyright (C) 2018  Ragnar Stroberg
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License along
+//    with this program; if not, write to the Free Software Foundation, Inc.,
+//    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+///////////////////////////////////////////////////////////////////////////////////
+
+
+#include <stdlib.h>
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <fstream>
+#include <stdio.h>
+#include <string>
+#include <omp.h>
+#include "../IMSRG.hh"
+#include "../Parameters.hh"
+#include "../PhysicalConstants.hh"
+#include "../version.hh"
+
+struct OpFromFile {
+   std::string file2name,file3name,opname;
+   int j,p,t,r; // J rank, parity, dTz, particle rank
+};
+
+int main(int argc, char** argv)
+{
+  // Default parameters, and everything passed by command line args.
+  std::cout << "######  imsrg++ build version: " << version::BuildVersion() << std::endl;
+
+  Parameters parameters(argc,argv);
+  if (parameters.help_mode) return 0;
+
+  int emax = parameters.i("emax_imsrg");
+  int emax_3body = parameters.i("emax_3body_imsrg");
+  int e3max = parameters.i("e3max_imsrg");
+  std::string ref = parameters.s("reference");
+  // We coopt emax for number of commutators here
+  int num_comms = parameters.i("emax");
+
+  ModelSpace ms(emax, emax_3body, ref, ref);
+  ms.SetE3max(e3max);
+
+  Operator op1 = Operator(ms, 0, 0, 0, 3);
+  op1.SetAntiHermitian();
+  op1.ThreeBody.SwitchToPN_and_discard();
+  Operator op2 = Operator(ms, 0, 0, 0, 3);
+  op2.SetHermitian();
+  op2.ThreeBody.SwitchToPN_and_discard();
+  Operator op3 = Operator(ms, 0, 0, 0, 3);
+  op3.SetHermitian();
+  op3.ThreeBody.SwitchToPN_and_discard();
+
+  for (int i = 0; i < num_comms; i+=1){
+    Commutator::comm232ss_new(op1, op2, op3);
+  }
+
+
+  op1.PrintTimes();
+
+  return 0;
+}


### PR DESCRIPTION
This is controlled by the parameter `emax_3body_imsrg`.

This also includes the improvements to the IMSRG solver. This has served me well for the past couple of weeks, but I don't test more extreme systems as much. I'm happy to comment it out or add a flag to enable the alternative solver.